### PR TITLE
Improved error output for build-tools scripts

### DIFF
--- a/tools/build-elf-tools.sh
+++ b/tools/build-elf-tools.sh
@@ -24,7 +24,7 @@
 MAKEJOBS=4
 
 if ! test -f src/src-release; then
-  echo "ERROR: missing GNU src tree."
+  echo "ERROR: missing GNU src tree (i.e., newlib and libgloss)."
   exit 1
 fi
 

--- a/tools/build-rtems-tools.sh
+++ b/tools/build-rtems-tools.sh
@@ -24,7 +24,7 @@
 MAKEJOBS=4
 
 if ! test -f src/src-release; then
-  echo "ERROR: missing GNU src tree."
+  echo "ERROR: missing GNU src tree (i.e., newlib and libgloss)."
   exit 1
 fi
 


### PR DESCRIPTION
Started building the tools on machine that was missing CVS, so newlib and libgloss weren't downloaded. "missing GNU src tree" was initially confusing, thought at first that it meant part of GCC was missing.
